### PR TITLE
demo.c generates uf2 and extra files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.1] - 2022-11-29
+## Fixed
+- Fix compilation error when making .uf2 target in demo
+
 ## [1.2.0] - 2021-06-15
 ### Added
 - Ability to wait for everything to be sent to display with the `TM1637_wait()`

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,4 +18,4 @@ add_executable(TM1637_demo demo.c)
 target_link_libraries(TM1637_demo PicoTM1637 pico_stdlib)
 
 # Uncomment for .uf2 output
-#pico_add_extra_outputs(TM1637_pico_test)
+#pico_add_extra_outputs(TM1637_demo)


### PR DESCRIPTION
Before this patch, cmake would crash when `pico_add_extra` option
would be turned on because `TM1637_pico_test` is an un-defined target.

This patch fixes it by replacing it with the current target.