### PR TITLE
Change pin handling to use 64-bit masks to support RP2350B

### DIFF
--- a/src/PicoTM1637.c
+++ b/src/PicoTM1637.c
@@ -65,9 +65,9 @@ void TM1637_init(uint clk, uint dio) {
 
   sm_config_set_sideset_pins(&smConfig, clkPin);
 
-  uint32_t both_pins = (1u << clkPin) | (1u << dioPin);
-  pio_sm_set_pins_with_mask(pio, sm, both_pins, both_pins);
-  pio_sm_set_pindirs_with_mask(pio, sm, both_pins, both_pins);
+  uint64_t both_pins = (1uLL << clkPin) | (1uLL << dioPin);
+  pio_sm_set_pins_with_mask64(pio, sm, both_pins, both_pins);
+  pio_sm_set_pindirs_with_mask64(pio, sm, both_pins, both_pins);
 
   sm_config_set_out_pins(&smConfig, dioPin, 1);
   sm_config_set_set_pins(&smConfig, dioPin, 1);


### PR DESCRIPTION
The RP2350B has 48 pins, so we need a 64 bit mask here. This PR leave it up to the user to call `pio_set_gpio_base(pio0, 16);` if needed. Using this branch, I am able to display properly using pins 35 and 36.